### PR TITLE
docs: add staging to production migration guide

### DIFF
--- a/docs/migration-staging-to-production.md
+++ b/docs/migration-staging-to-production.md
@@ -1,0 +1,35 @@
+# Migrating from Staging to Production
+
+Promote changes from staging to production with care for schema and data.
+
+## Applying new Prisma migrations
+
+Run pending migrations against the production database during deployments:
+
+```bash
+npx prisma migrate deploy
+```
+
+This applies existing migration files without generating new ones.
+
+## Transferring table data
+
+Use PostgreSQL tools to copy data between environments:
+
+```bash
+pg_dump "$STAGING_DATABASE_URL" | pg_restore --dbname="$PRODUCTION_DATABASE_URL"
+```
+
+For simpler cases, Prisma can synchronize schemas and data:
+
+```bash
+npx prisma db pull --url "$STAGING_DATABASE_URL"
+npx prisma db push --url "$PRODUCTION_DATABASE_URL"
+```
+
+Choose the method that fits your needs for data fidelity and downtime.
+
+## Environment configuration
+
+Keep environment-specific settings such as database URLs in separate `.env` files (e.g., `.env.staging` and `.env.production`). Ensure deployment scripts reference the appropriate configuration when running migrations or transferring data.
+


### PR DESCRIPTION
## Summary
- document how to apply Prisma migrations during deployment
- outline data transfer approaches for promoting staging data
- note managing environment-specific database configuration

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ef51eeec83228768a44a8c7b002d