### PR TITLE
Add Docker configuration for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# NextJS-NestJS-Prisma-PostgreSQL-Template
+# NextJS-NestJS-Prisma-PostgreSQL Template
+
+This repository provides a starting point for deploying a Next.js frontend and NestJS backend with PostgreSQL.
+
+## Local development
+
+Run PostgreSQL locally using Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+The database service exposes the following environment variables and defaults:
+
+- `POSTGRES_USER` (default: `postgres`)
+- `POSTGRES_PASSWORD` (default: `postgres`)
+- `POSTGRES_DB` (default: `postgres`)
+
+Modify these values in `docker-compose.yml` or an `.env` file as needed.
+
+## Building Docker images
+
+Build the backend and frontend images:
+
+```bash
+docker build -t template-backend ./backend
+docker build -t template-frontend ./frontend
+```
+
+Run the images with required environment variables:
+
+```bash
+docker run -e DATABASE_URL=postgres://postgres:postgres@db:5432/postgres template-backend
+docker run -e NEXT_PUBLIC_API_URL=http://localhost:3000 template-frontend
+```
+
+## Push to Amazon ECR for Fargate
+
+1. Create ECR repositories:
+
+```bash
+aws ecr create-repository --repository-name template-backend
+aws ecr create-repository --repository-name template-frontend
+```
+
+2. Authenticate Docker to your registry:
+
+```bash
+aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
+```
+
+3. Tag and push the images:
+
+```bash
+docker tag template-backend:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/template-backend:latest
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/template-backend:latest
+
+docker tag template-frontend:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/template-frontend:latest
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/template-frontend:latest
+```
+
+4. Use the pushed image URIs in your ECS task definitions and deploy on AWS Fargate.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,21 @@
+# Backend Dockerfile for NestJS
+# Use official Node.js LTS version
+FROM node:18-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+# Expose application port
+EXPOSE 3000
+CMD ["node", "dist/main.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:
+    driver: local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,22 @@
+# Frontend Dockerfile for Next.js
+# Use official Node.js LTS version
+FROM node:18-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/next.config.js ./next.config.js
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for NestJS backend and Next.js frontend
- set up docker-compose with PostgreSQL for local development
- document build instructions, env vars, and ECR push steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ef5310308322abfd941e6a4f1131