### PR TITLE
docs: add backend guidelines

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,15 @@
+* Overview of the backend’s purpose and high‑level architecture (monolith vs. microservices) and major modules/services.
+* Directory layout (`src/`, `test/`, `scripts/`, `config/`, `docker/`, `infra/`, `docs/`) and where controllers, services, modules, DTOs, and interfaces reside under `src/`.
+* Environment configuration: description of `.env.development`, `.env.staging`, `.env.production` and required variables (`DATABASE_URL`, `JWT_SECRET`, `REDIS_HOST`, `SENTRY_DSN`, `MAILER_API_KEY`); how `ConfigModule` loads files by `NODE_ENV`.
+* Build and startup commands for development (`npm install`, `npm run start:dev`), production (`npm run build`, `npm run start:prod`), and Docker usage (`docker build`, `docker run --env-file .env.production`).
+* Linting & formatting setup (ESLint, Prettier, husky, lint-staged) and CI lint checks (`npm run lint`).
+* Testing instructions (`npm run test`, `npm run test:cov` with coverage thresholds).
+* Dependency management guidelines (dev dependencies only for build/test tools; compile before running).
+* Security practices (AWS Secrets Manager or Vault, `helmet`, CORS, rate limiting).
+* Database and migration commands (`npm run migration:generate -- -n <Name>`, `npm run migration:run`), plus retry/backoff strategy.
+* Monitoring & logging (Winston/Pino, `/health`, `/metrics`, Sentry/DataDog).
+* Message queues/background agents and how to start them (`npm run start:worker`, scheduling info).
+* CI/CD workflow steps (install → lint → test → build → deploy; secrets handling).
+* Deployment & orchestration notes (PM2 or Kubernetes/Helm examples, resource limits).
+* Debugging tools (`npm run start:debug`, Swagger at `/api`, local mocks via `docker-compose.yml`).
+* Documentation references (`.eslintrc.js`, `.prettierrc`, README), naming conventions, validation pipe usage, module registration hints.


### PR DESCRIPTION
## Summary
- document backend architecture, environment setup, development commands, testing, security, monitoring, and deployment notes in `backend/AGENTS.md`

## Testing
- `npm run lint` *(fails: ENOENT: no such file or directory, open 'backend/package.json')*
- `npm run test` *(fails: ENOENT: no such file or directory, open 'backend/package.json')*
- `npm run test:cov` *(fails: ENOENT: no such file or directory, open 'backend/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6893f1f2d7108322980a3c46983a483f