### PR TITLE
chore: format AGENTS guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,204 +1,77 @@
-<!-- This AGENTS.md file lives at the root of the monorepo and serves as the authoritative reference for AI agents, developers, and CI systems when working with this project. It aggregates and summarizes the rules and procedures defined in the backend and frontend AGENTS files and adds global guidance applicable across the entire codebase. Keep this file up to date whenever the repository structure or workflows change. -->
-Root AGENTS Guide
-🧭 Purpose & Overview
-Why this file exists: To instruct AI agents (such as Codex), new
-developers, and CI tools on how to operate within this monorepo. It
-consolidates high‑level rules and points to service‑specific files
-(backend/AGENTS.md and frontend/AGENTS.md).
+# Monorepo AGENTS Guide
 
-Repository composition: This monorepo contains at least two
-top‑level packages:
+> Authoritative instructions for AI agents, developers, and CI/CD systems working in this repository.
 
-backend/ – A NestJS API with Prisma for database access. See
-backend/AGENTS.md for deep details.
+## Table of Contents
+- [Purpose & Overview](#purpose--overview)
+- [Repository Structure](#repository-structure)
+- [Setup & Dependencies](#setup--dependencies)
+- [Environment Configuration](#environment-configuration)
+- [Linting, Formatting & Testing](#linting-formatting--testing)
+- [Running & Building](#running--building)
+- [Security & Compliance](#security--compliance)
+- [Database & Migrations](#database--migrations)
+- [Monitoring & Logging](#monitoring--logging)
+- [Agent Conventions](#agent-conventions)
+- [References](#references)
 
-frontend/ – A Next.js web application that consumes the API and
-uses Prisma only on the server. See frontend/AGENTS.md for
-specifics.
+## Purpose & Overview
+- Central guide for the entire monorepo.
+- Points to service specific instructions in `backend/AGENTS.md` and `frontend/AGENTS.md`.
 
-shared/ (optional) – Modules or libraries shared between
-packages; keep shared code framework‑agnostic (e.g., utility
-functions, TypeScript types). Do not import backend code
-directly into the frontend.
+## Repository Structure
+- **backend/** – NestJS API using Prisma. See `backend/AGENTS.md`.
+- **frontend/** – Next.js web app. See `frontend/AGENTS.md`.
+- **shared/** *(optional)* – Framework‑agnostic utilities and types.
+- Root configs: `.editorconfig`, `.prettierrc`, `.eslintrc.js`, `package.json`, `README.md`.
 
-🗃 Directory Layout
-At the root, you’ll find configuration and tooling files such as
-.editorconfig, .prettierrc, .eslintrc.js, package.json,
-pnpm-workspace.yaml (or package.json#workspaces) and README.md.
+## Setup & Dependencies
+- Uses npm workspaces; run `npm install` at the root to install all packages.
+- Add cross‑package devDependencies to the root `package.json`.
+- `npm run bootstrap` (if present) links local packages and generates Prisma clients.
 
-Each package (backend/, frontend/, shared/) contains its own
-src/, test/, prisma/ (if it uses Prisma), and an individual
-AGENTS.md describing its internals. Read them before making
-changes to that part of the codebase.
+## Environment Configuration
+- Each package maintains its own `.env.development`, `.env.staging`, `.env.production` files.
+- Avoid root `.env` unless variables are truly global.
+- **NEXT_PUBLIC_** prefix exposes variables to the browser; never store secrets with this prefix.
+- Production secrets live in services such as AWS Secrets Manager or Vault.
 
-🛠 Setup & Dependencies
-Workspace manager: This repository uses npm workspaces (or
-pnpm/yarn workspaces depending on package.json). Run npm install at the root to install dependencies for all packages.
+## Linting, Formatting & Testing
+- ESLint and Prettier are configured at the root.
+- Pre‑commit hooks via Husky and lint‑staged run formatting and linting on staged files.
+- Run tests with `npm test` (all workspaces) or `npm test --workspace <pkg>`.
 
-Per‑package installs: Avoid running npm install inside
-packages unless adding a new dependency scoped to that package. For
-dev‑dependencies that span packages (e.g. testing tools), add them
-to the root package.json.
+## Running & Building
+- `npm run dev` starts backend and frontend together for local development.
+- `npm run build` compiles both packages.
+- `npm run start` (or `npm run start --workspace <pkg>`) runs the production build.
+- Each service has a `Dockerfile`; build with `docker build -t repo-backend backend/` or `repo-frontend frontend/`.
 
-Bootstrap script: If available, run npm run bootstrap to link
-local packages and generate Prisma clients where necessary.
+## Security & Compliance
+- Backend uses Helmet, CORS whitelist, and rate limiting.
+- Frontend should configure a strict Content Security Policy via `next.config.js` headers.
+- Never commit secrets to git; manage them via environment variables or secret managers.
 
-🌿 Environment Configuration
-Global variables: Secrets and runtime configuration should live
-in environment files. Each package has its own .env.* files
-(.env.development, .env.staging, .env.production). Do not
-create a single .env at the root unless you need truly global
-variables. Next.js loads envs in a specific order: first from
-.env.$(NODE_ENV).local, then .env.local, .env.$(NODE_ENV) and
-finally .env
-nextjs.org
-. NEXT_PUBLIC_ prefixed
-variables are exposed to the browser
-nextjs.org
-; never
-leak secrets with this prefix.
+## Database & Migrations
+- Prisma schemas live in `prisma/schema.prisma` within each package.
+- Apply migrations locally with `npx prisma migrate dev --name <change>`.
+- During deployment run `npx prisma migrate deploy` before starting services.
+- See `docs/migration-staging-to-production.md` for migrating data between environments.
 
-Back‑end secrets: Use AWS Secrets Manager or Vault for
-production secrets. Do not commit secrets to git. The backend’s
-ConfigModule loads the correct .env file based on NODE_ENV
-and exposes a ConfigService
+## Monitoring & Logging
+- Use structured logging (Pino/Winston) with request IDs.
+- Expose `/health` endpoints in both services for uptime checks.
+- Integrate Sentry or similar tools for error tracking.
 
-docs.nestjs.com
-.
+## Agent Conventions
+- Follow naming and workflow rules in service AGENTS files before modifying code.
+- Write TypeScript everywhere; avoid the `any` type and keep shared types in `shared/`.
+- Database queries run server‑side only; never import Prisma Client into React components.
+- Prefix client‑side environment variables with `NEXT_PUBLIC_`.
 
-Prisma URLs: DATABASE_URL should be defined per environment
-(development/staging/production). Do not hard‑code credentials.
-
-🧪 Linting, Formatting & Testing
-Code quality: The root sets up ESLint and Prettier config for
-the entire repo. Pre‑commit hooks (via Husky and lint‑staged)
-automatically run linters on staged files. CI pipelines will fail
-if linting errors persist.
-
-Testing: Each package contains its own test suite. Use npm test at the root to run all tests concurrently, or npm test --workspace <pkg> to run a specific package’s tests. Coverage
-thresholds are enforced.
-
-🚀 Running & Building
-Development: Run npm run dev at the root to start the
-frontend and backend concurrently (via concurrently or nx run).
-This spins up the NestJS server (backend/start:dev) and Next.js
-dev server (frontend/dev).
-
-Production build: Use npm run build to compile both
-packages. For the frontend, next build produces the .next
-directory and next start runs a Node.js server
-nextjs.org
-.
-For the backend, nest build compiles TypeScript; npm run start:prod runs the compiled server. Ensure you run npx prisma migrate deploy before starting in production to apply pending
-migrations
-prisma.io
-.
-
-Docker: Each package has its own Dockerfile. Build with
-docker build -t repo-backend backend/ or repo-frontend frontend/.
-Pass environment files via --env-file .env.production. For a
-unified container, use docker-compose.yml in deploy/.
-
-🛡 Security & Compliance
-HTTP security: The backend registers helmet middleware to
-set secure HTTP headers
-
-docs.nestjs.com
-. Do not remove this.
-
-CORS & rate limiting: CORS is enabled with a whitelist; global
-rate limiting is configured via @nestjs/throttler. Do not expose
-endpoints without these protections.
-
-Frontend CSP: Add a strict Content Security Policy in
-next.config.js or via custom headers to mitigate XSS
-nextjs.org
-.
-
-🔄 Database & Migrations
-Prisma workflow: Models live in prisma/schema.prisma within
-each package. After editing the schema, run npx prisma migrate dev --name <change> in the appropriate package to generate and
-apply a migration
-prisma.io
-. Commit the generated
-SQL files. Running prisma migrate dev also triggers prisma generate to update the client
-prisma.io
-.
-
-Deploying migrations: In CI/CD, run npx prisma migrate deploy
-before starting the server. Never apply migrations manually on
-production databases.
-
-📈 Monitoring & Logging
-Logging: Use structured logging (pino or winston) across
-packages. Include request IDs so that logs from frontend to backend
-can be correlated.
-
-Health checks: Expose /api/health in both apps. Uptime
-monitors should hit these endpoints.
-
-Error tracking: Integrate Sentry (backend and frontend). In
-production, unhandled exceptions should report to Sentry or a
-similar service.
-
-🤖 Agent‐Specific Conventions
-Follow package guidelines: When updating backend or frontend
-code, always consult the respective AGENTS.md files for naming
-conventions, module registration patterns, and test commands.
-
-Type safety: Write all code in TypeScript. Never use the any
-type; instead, define proper interfaces in the shared/ package.
-
-Prisma usage: Do not import Prisma Client into React components.
-All database queries must run server‑side. In the backend, use
-dependency injection for PrismaService.
-
-Environment variables: Always check whether a variable should be
-server‑only or exposed to the browser. Prefix browser‑exposed vars
-with NEXT_PUBLIC_
-nextjs.org
- and avoid secrets in
-those variables.
-
-Secrets: Do not commit any secrets, tokens, or private keys.
-
-Commit hygiene: Write descriptive commit messages. Keep PRs
-small and focused; include relevant tests.
-
-Third‑party libs: Evaluate dependencies carefully. Add
-polyfills or shims only at the root; avoid duplicating dependencies
-across packages.
-
-📚 References
-Next.js environment variables guide: explains loading order and
-NEXT_PUBLIC_ semantics
-nextjs.org
-.
-
-Next.js production checklist: details code splitting, image
-optimization, font hosting and CSP
-nextjs.org
-.
-
-NestJS configuration module: describes how to manage
-environment variables via ConfigModule
-
-docs.nestjs.com
-.
-
-Prisma migrations: outlines the workflow for generating and
-applying migrations
-prisma.io
-.
-
-Helmet security middleware: secures Express/NestJS apps via
-HTTP headers
-
-docs.nestjs.com
-.
-
-By adhering to the rules in this root AGENTS guide and the
-package‑specific AGENTS files, AI assistants and developers can work
-efficiently and securely across the entire stack. Consistency and
-discipline here reduce friction and prevent subtle bugs when multiple
-services interact.
+## References
+- [Next.js Environment Variables Guide](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables)
+- [Next.js Production Checklist](https://nextjs.org/docs/pages/guides/production-checklist)
+- [NestJS ConfigModule Docs](https://docs.nestjs.com/techniques/configuration)
+- [Prisma Migrate Docs](https://www.prisma.io/docs/concepts/components/prisma-migrate)
+- [Helmet Middleware](https://docs.nestjs.com/security/helmet)

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,136 +1,83 @@
-🎨 Frontend AGENTS.md – Next.js + Prisma
-Purpose & layout
+# Frontend AGENTS Guide – Next.js + Prisma
 
-Summarize the app’s purpose (e.g., job board UI, dashboards, candidate portal).
+## Table of Contents
+- [Purpose & Layout](#purpose--layout)
+- [Environment Configuration](#environment-configuration)
+- [Prisma on the Frontend](#prisma-on-the-frontend)
+- [Development & Production Workflow](#development--production-workflow)
+- [Linting, Formatting & Testing](#linting-formatting--testing)
+- [Performance Best Practices](#performance-best-practices)
+- [Security](#security)
+- [Monitoring & Logging](#monitoring--logging)
+- [Agent Hints & Conventions](#agent-hints--conventions)
+- [References & Docs](#references--docs)
 
-Describe folder structure: src/app/ or pages/ (routes), components/, prisma/ (for client hooks or queries), public/, styles/, lib/, config/.
+## Purpose & Layout
+- Describes the Next.js application (e.g. dashboards, portals, etc.).
+- Directory structure:
+  - `src/app/` or `pages/` – routes.
+  - `components/`, `lib/`, `public/`, `styles/`, `prisma/`.
+  - Config files: `next.config.js`, `tsconfig.json`, `.env*`.
 
-Note config files: next.config.js, tsconfig.json, .env.*.
+## Environment Configuration
+- Use `.env.local` for developer secrets (ignored by git) and `.env.development`, `.env.production`, `.env.test` for environment values.
+- Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser; keep secrets unprefixed.
+- Loading order: `.env.$(NODE_ENV).local` → `.env.local` → `.env.$(NODE_ENV)` → `.env`.
 
-Environment configuration
+## Prisma on the Frontend
+- Prisma Client should only run on the server (API routes, server components, or `getServerSideProps`).
+- Create `lib/prisma.ts` to instantiate and cache the client.
+- Never import Prisma Client into client components.
 
-Use separate env files: .env.local for developer‑specific secrets (ignored by git), .env.development, .env.production, .env.test.
+## Development & Production Workflow
+- **Local development**
+  ```bash
+  npm install
+  npm run dev
+  ```
+- **Production build**
+  ```bash
+  npm run build
+  npm run start
+  ```
+- **Docker**
+  ```bash
+  docker build -t frontend:latest .
+  docker run -p 3000:3000 --env-file .env.production frontend:latest
+  ```
+- Recommended hosting: Vercel, Netlify, AWS Amplify or containerized on Fargate.
 
-Document every variable and which are exposed via NEXT_PUBLIC_*.
+## Linting, Formatting & Testing
+- ESLint + Prettier with `next lint` integration.
+- Husky and lint-staged enforce formatting on commit.
+- Jest + React Testing Library: `npm run test` and `npm run test:cov` (≥80% coverage).
+- CI steps: install → lint → test → build.
 
-Next.js loads env variables in order: process.env → .env.$(NODE_ENV).local → .env.local → .env.$(NODE_ENV) → .env
-nextjs.org
-.
+## Performance Best Practices
+- Automatic code splitting, prefetching and static optimization are built in.
+- Use `next/image` for optimized images and `next/font` for self-hosted fonts.
+- Employ dynamic imports and lazy loading for heavy components.
+- Configure gzip/Brotli compression and caching headers.
+- Use Incremental Static Regeneration (ISR) where applicable.
 
-Only variables prefixed with NEXT_PUBLIC_ are bundled into client JS
-nextjs.org
-; others remain server‑only.
+## Security
+- Do not commit `.env` files.
+- Enforce strict Content Security Policy via `next.config.js` headers and consider using `helmet`.
+- Enable HTTPS, HSTS and configure CORS for API routes.
 
-For runtime envs, expose via APIs or server‑side functions.
+## Monitoring & Logging
+- Provide `/api/health` endpoint for uptime checks.
+- Use structured logging (JSON with correlation IDs).
+- Integrate Sentry or LogRocket for error tracking.
 
-Prisma on the frontend
+## Agent Hints & Conventions
+- Route files use `*.page.tsx`; API routes use `*.api.ts`.
+- Hooks start with `use*`; context providers end with `*Provider`.
+- Shared types reside in `src/types`.
+- Regenerate Prisma client and update server components when schema changes.
+- Use `<Link>` for navigation to leverage automatic prefetching.
 
-Use Prisma Client only on the server (API routes, getServerSideProps or server components). Never import Prisma Client into client‑side code.
-
-For data fetching, create /lib/prisma.ts to instantiate and reuse the client; handle connection caching in dev.
-
-Development & production workflow
-
-Local dev: npm install → npm run dev (hot reload).
-
-Production build: npm run build → npm run start – this builds and starts a Node.js server
-nextjs.org
-; run locally to catch errors before deployment
-nextjs.org
-.
-
-Docker: show Dockerfile example; run with docker build and docker run -p 3000:3000 --env-file .env.production.
-
-Advise using Vercel or AWS Amplify for hosting; containerize only if necessary.
-
-Linting, formatting & testing
-
-Set up eslint + prettier with next lint integration
-nextjs.org
-.
-
-Use Husky + lint‑staged for pre‑commit checks.
-
-Unit tests with Jest & React Testing Library; enforce ≥80 % coverage.
-
-In CI: install → lint → test → build.
-
-Performance best practices
-
-Rely on Next.js automatic optimizations:
-
-Code splitting: Next.js automatically splits code by pages so only what’s needed is loaded on navigation
-nextjs.org
-.
-
-Prefetching: Routes are prefetched when links enter the viewport
-nextjs.org
-.
-
-Automatic static optimization: pages without blocking data are pre-rendered and cached
-nextjs.org
-.
-
-Use next/image to automatically optimize images and serve modern formats
-nextjs.org
-; Image extends <img> for automatic optimization
-nextjs.org
-.
-
-Use next/font to self‑host fonts and remove external requests
-nextjs.org
-.
-
-Employ dynamic imports for heavy libraries and enable lazy loading.
-
-Enable compression (gzip/Brotli) and caching headers via CDN or custom server.
-
-Use Incremental Static Regeneration (ISR) and proper cache settings to update content without full rebuild.
-
-Security
-
-Never commit .env files to the repo
-nextjs.org
-.
-
-Add strict Content Security Policy and use helmet (or Next.js’ securityHeaders in next.config.js).
-
-Enforce HTTPS and HSTS; configure CORS for API routes.
-
-Monitoring & logging
-
-Expose an /api/health endpoint for uptime checks.
-
-Use structured logs (JSON) and include correlation IDs; pipe to log service.
-
-Integrate Sentry or LogRocket for error and session tracking.
-
-Agent hints & conventions
-
-Route files: *.page.tsx or nested segments in app/; API routes: *.api.ts.
-
-Hooks must start with use*; context providers end with *Provider.
-
-Shared types live in src/types.
-
-When working with the Prisma schema, regenerate the client and update server components accordingly.
-
-Avoid importing Prisma Client in client components—keep DB access server‑side.
-
-Use the Link component for client navigation and automatic prefetching
-nextjs.org
-.
-
-References & docs
-
-Link to Next.js environment variables guide
-nextjs.org
-.
-
-Link to Next.js production checklist for performance/security tips
-nextjs.org
-.
-
-Link to Prisma docs for migration workflows
-prisma.io
-.
+## References & Docs
+- [Next.js Environment Variables Guide](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables)
+- [Next.js Production Checklist](https://nextjs.org/docs/pages/guides/production-checklist)
+- [Prisma Docs](https://www.prisma.io/docs)


### PR DESCRIPTION
## Summary
- rework root AGENTS guide with table of contents and global practices
- convert backend AGENTS instructions into README-style sections
- format frontend AGENTS documentation for clarity and quick reference

## Testing
- `npm test` *(fails: missing package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6893eef046188322b4b9546ea22811c8