### PR TITLE
chore: add sample env files

### DIFF
--- a/backend/.env.development
+++ b/backend/.env.development
@@ -1,0 +1,6 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+JWT_SECRET=dev_jwt_secret
+REDIS_HOST=localhost
+SENTRY_DSN=
+MAILER_API_KEY=
+PORT=3000

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -1,0 +1,6 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+JWT_SECRET=prod_jwt_secret
+REDIS_HOST=localhost
+SENTRY_DSN=
+MAILER_API_KEY=
+PORT=3000

--- a/backend/.env.staging
+++ b/backend/.env.staging
@@ -1,0 +1,6 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+JWT_SECRET=staging_jwt_secret
+REDIS_HOST=localhost
+SENTRY_DSN=
+MAILER_API_KEY=
+PORT=3000

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://api.example.com

--- a/frontend/.env.staging
+++ b/frontend/.env.staging
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://staging.api.example.com


### PR DESCRIPTION
## Summary
- add backend and frontend environment configs for development, staging, and production

## Testing
- `docker-compose up -d` *(fails: Error while fetching server API version)*
- `npm run start` (backend)
- `npm run start` (frontend)
- `npm run build` (backend)
- `npm run build` (frontend)
- `npm run lint` (backend) *(fails: 7 errors, 1 warning)*
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68942e42602883229432a22507dce796